### PR TITLE
Avoid multiple outputs with multimatch; genotype checking for noref

### DIFF
--- a/truvari.py
+++ b/truvari.py
@@ -897,6 +897,9 @@ def run(cmdargs):
                 stats_box["TP-base"] += 1
             if not matched_calls[c_key]:
                 stats_box["TP-call"] += 1
+                write_tp_call = True
+            else:
+                write_tp_call = False
             # Mark the call for multimatch checking
             matched_calls[b_key] = True
             matched_calls[c_key] = True
@@ -905,7 +908,8 @@ def run(cmdargs):
             annotate_tp(match_entry, *thresh_neighbors[0])
 
             tpb_out.write_record(base_entry)
-            tpc_out.write_record(match_entry)
+            if write_tp_call:
+                tpc_out.write_record(match_entry)
             logging.debug("Matching %s and %s", str(base_entry), str(match_entry))
         else:
             stats_box["FN"] += 1
@@ -938,7 +942,7 @@ def run(cmdargs):
         if size < args.sizemin or size > args.sizemax:
             c_filt.write_record(entry)
             stats_box["call size filtered"] += 1
-        elif args.no_ref and not entry.genotype(sampleB)["GT"].is_variant:
+        elif args.no_ref and not entry.genotype(sampleB).is_variant:
             stats_box["call gt filtered"] += 1
         elif regions.include(entry):
             fp_out.write_record(entry)


### PR DESCRIPTION
Thanks so much for this tool. I've been working on incorporating it into bcbio for more flexible SV validation outputs and ran into a couple of small things that this patch fixes. Thanks again.

Two small fixes:

- `--multimatch` -- avoid writing matches multiple times in output VCFs.
- `--noref` -- Fixes check for genotype GT lookup