### PR TITLE
Fix issue processing base variants w/ FILTER=.

### DIFF
--- a/truvari.py
+++ b/truvari.py
@@ -781,8 +781,9 @@ def run(cmdargs):
             b_filt.write_record(base_entry)
             continue
 
-        if args.passonly and len(base_entry.FILTER):
+        if args.passonly and (base_entry.FILTER is None or len(base_entry.FILTER)):
             continue
+
         stats_box["base cnt"] += 1
 
         fetch_start, fetch_end = fetch_coords(span_lookup, base_entry, args.refdist)

--- a/truvari.py
+++ b/truvari.py
@@ -781,7 +781,7 @@ def run(cmdargs):
             b_filt.write_record(base_entry)
             continue
 
-        if args.passonly and (base_entry.FILTER is None or len(base_entry.FILTER)):
+        if args.passonly and (base_entry.FILTER is not None and len(base_entry.FILTER)):
             continue
 
         stats_box["base cnt"] += 1


### PR DESCRIPTION
When working with --passonly, base-variants with original FILTER=. have value = None, but are assumed to always be an array. This caused TruVari to throw when attempting to len(base_entry.FILTER)