### PR TITLE
Bug Fix: Cannot sort list with  'pysam.libcbcf.VariantRecord' element

### DIFF
--- a/truvari/truvari
+++ b/truvari/truvari
@@ -899,7 +899,7 @@ def main(cmdargs):
         base_entry.info["NumThresholdNeighbors"] = len(thresh_neighbors)
         base_entry.info["MatchId"] = pbarcnt
         if len(thresh_neighbors) > 0:
-            thresh_neighbors.sort(reverse=True)
+            thresh_neighbors.sort(reverse=True, key=itemgetter(0))
             logging.debug("Picking from candidate matches:\n%s", "\n".join([str(x) for x in thresh_neighbors]))
 
             match_score, match_pctsim, match_pctsize, match_ovlpct, match_szdiff, \


### PR DESCRIPTION
Latest version 1.3.1 fails with error message:

```
Traceback (most recent call last):
  File .../venv/bin/truvari, line 1044, in <module>
    main(sys.argv[1:])
  File .../venv/bin/truvari, line 902, in main
    thresh_neighbors.sort(reverse=True)
TypeError: '<' not supported between instances of 'pysam.libcbcf.VariantRecord' and 'pysam.libcbcf.VariantRecord'
````
I am assuming the records should be sorted by 'score' in descending order.