### PR TITLE
Add Deployed Documentation Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 Structural variant toolkit for benchmarking, annotating and more for VCFs
 
 [WIKI page](https://github.com/spiralgenetics/truvari/wiki) has detailed documentation.
+
+You can also checkout the [deployed documentation](https://docs.contour.so/spiralgenetics/truvari).
+
 See [Updates](https://github.com/spiralgenetics/truvari/wiki/Updates) on new versions.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@
 
 Structural variant toolkit for benchmarking, annotating and more for VCFs
 
-[WIKI page](https://github.com/spiralgenetics/truvari/wiki) has detailed documentation.
-
-You can also checkout the [deployed documentation](https://docs.contour.so/spiralgenetics/truvari).
+[WIKI page](https://github.com/spiralgenetics/truvari/wiki) has detailed documentation. You can also checkout the [deployed documentation](https://docs.contour.so/spiralgenetics/truvari).
 
 See [Updates](https://github.com/spiralgenetics/truvari/wiki/Updates) on new versions.
 
@@ -50,6 +48,6 @@ The current most common Truvari use case is for structural variation benchmarkin
 
 ## More Information
 
-Find more details and discussions about Truvari on the [WIKI page](https://github.com/spiralgenetics/truvari/wiki).
+Find more details and discussions about Truvari on the [WIKI page](https://github.com/spiralgenetics/truvari/wiki) or the [documentation](https://docs.contour.so/spiralgenetics/truvari).
 
 [https://www.spiralgenetics.com](https://www.spiralgenetics.com)


### PR DESCRIPTION
Here's the [documentation](https://docs.contour.so/spiralgenetics/truvari) deployed from the Wiki! 

The platform should be a much more pleasant writing experience (a WYSIWIG Markdown Editor). You can also query sections of the reference docs, which autogenerates periodically, and it'll tell you if it's grown outdated. 

You need to sign in though to make edits (takes less than 1 min) so that a random person can't make edits 😄.

JIC you're wondering, exports to Markdown & GH Wiki will soon be supported as well.