### PR TITLE
Fix if condition

### DIFF
--- a/truvari/genome_tree.py
+++ b/truvari/genome_tree.py
@@ -42,7 +42,7 @@ class GenomeTree():
             logging.info("Including %d bed regions", counter)
         else:
             excluding = contigB_set - contigA_set
-            if not excluding:
+            if excluding:
                 logging.warning(
                     "Excluding %d contigs present in comparison calls header but not base calls.", len(excluding))
 


### PR DESCRIPTION
With current if statement `if not excluding:`, Truvari only logs a message "Excluding 0 contigs present in comparison calls header but not base calls." when `excluding` is an empty set. By changing the if statement to `if excluding:`, Truvari logs a meaningful message when there are contigs excluded.